### PR TITLE
Fix extension icon rendering

### DIFF
--- a/src/background-icon.ts
+++ b/src/background-icon.ts
@@ -5,7 +5,10 @@ import { BrowserAction } from './types';
 
 const store = new TabStore(BrowserAction.Background);
 const theme = new Theme();
-const icon = new Icon(devicePixelRatio * 2, theme);
+// devicePixelRatio is undefined in extension service workers in some browsers
+// (notably Chrome). Fallback to 1 when it isn't available so the icon canvas
+// has a sensible size.
+const icon = new Icon((globalThis.devicePixelRatio ?? 1) * 2, theme);
 
 store.windowListeners.add(render);
 theme.listeners.add(render);


### PR DESCRIPTION
the icon doesn't the show the number of tabs. this is an attempted fix.

## Summary
- fix devicePixelRatio undefined in background service worker

## Testing
- `bun install`
- `npx tsc`

`dprint` plugins failed to download due to network restrictions.

------
https://chatgpt.com/codex/tasks/task_e_68829e339e18832688346d26d278fc64